### PR TITLE
Update packages.json to latest versions of dependencies

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -3,15 +3,15 @@
   "version": "1.0.0",
   "description": "songhop: An Ionic project",
   "dependencies": {
-    "gulp": "^3.5.6",
-    "gulp-sass": "^0.7.1",
-    "gulp-concat": "^2.2.0",
-    "gulp-minify-css": "^0.3.0",
-    "gulp-rename": "^1.2.0"
+    "gulp": "^3.8.11",
+    "gulp-sass": "^1.3.3",
+    "gulp-concat": "^2.5.2",
+    "gulp-minify-css": "^1.1.1",
+    "gulp-rename": "^1.2.2"
   },
   "devDependencies": {
-    "bower": "^1.3.3",
-    "gulp-util": "^2.2.14",
-    "shelljs": "^0.3.0"
+    "bower": "^1.4.1",
+    "gulp-util": "^3.0.4",
+    "shelljs": "^0.4.0"
   }
 }


### PR DESCRIPTION
The tutorial won't build on (at least) Win 7/8, 64 bit. With these latest versions it build OK, not sure if there are any breaking changes, but the base project loads fine with ionic serve.